### PR TITLE
maxTickBacklog and agressiveScaleback features

### DIFF
--- a/src/main/java/com/dynview/Utils/TickTimeHandler.java
+++ b/src/main/java/com/dynview/Utils/TickTimeHandler.java
@@ -1,6 +1,8 @@
 package com.dynview.Utils;
 
+import com.dynview.DynView;
 import com.dynview.ViewDistHandler.ServerDynamicViewDistanceManager;
+import net.minecraft.Util;
 import net.minecraft.server.MinecraftServer;
 
 public class TickTimeHandler
@@ -8,6 +10,7 @@ public class TickTimeHandler
     private int meanTickSum   = 50;
     private int meanTickCount = 1;
     private int tickTimer     = 0;
+    private int agroScalebackLimiter = 0;
 
     public static int serverTickTimerInterval = 100;
 
@@ -30,6 +33,24 @@ public class TickTimeHandler
      */
     public void onServerTick(final MinecraftServer server)
     {
+        long tickBacklog = (Util.getMillis() - server.getNextTickTime()) / 50;
+//        LOGGER.warn("Tick backlog:"+tickBacklog);
+        if ((DynView.config.getCommonConfig().aggressiveScalebackEnabled) &&
+            (tickBacklog > agroScalebackLimiter) &&
+            (tickBacklog > DynView.config.getCommonConfig().maxTickBacklog))
+        {
+            if (DynView.config.getCommonConfig().logMessages)
+            {
+                agroScalebackLimiter = Math.toIntExact(tickBacklog + 10); // Pause for 10 ticks, unless delay goes way up.
+                DynView.LOGGER.info("Agressive scaleback. (Tick Backlog: "+tickBacklog+")");
+            }
+            ServerDynamicViewDistanceManager.getInstance().updateViewDistForMeanTick(serverMeanTickTime, tickBacklog);
+        }
+        if (agroScalebackLimiter > 0)
+        {
+            agroScalebackLimiter--;
+        }
+//        LOGGER.warn("MeanTickSum:"+meanTickSum+" meanTickCount:"+meanTickCount+" tickTimer:"+tickTimer);
         tickTimer++;
 
         if (tickTimer % 20 == 0)
@@ -44,7 +65,7 @@ public class TickTimeHandler
                 meanTickCount = 0;
                 meanTickSum = 0;
 
-                ServerDynamicViewDistanceManager.getInstance().updateViewDistForMeanTick(serverMeanTickTime);
+                ServerDynamicViewDistanceManager.getInstance().updateViewDistForMeanTick(serverMeanTickTime, tickBacklog);
             }
         }
     }

--- a/src/main/java/com/dynview/ViewDistHandler/IDynamicViewDistanceManager.java
+++ b/src/main/java/com/dynview/ViewDistHandler/IDynamicViewDistanceManager.java
@@ -14,7 +14,7 @@ public interface IDynamicViewDistanceManager
      *
      * @param meanTick mean tick time
      */
-    void updateViewDistForMeanTick(final int meanTick);
+    void updateViewDistForMeanTick(final int meanTick, final long tickBacklog);
 
     void setCurrentChunkViewDist(int currentChunkViewDist);
 

--- a/src/main/java/com/dynview/ViewDistHandler/ServerDynamicViewDistanceManager.java
+++ b/src/main/java/com/dynview/ViewDistHandler/ServerDynamicViewDistanceManager.java
@@ -77,7 +77,7 @@ public class ServerDynamicViewDistanceManager implements IDynamicViewDistanceMan
         }
 
         if ((meanTickTime + UPDATE_LEEWAY < DynView.config.getCommonConfig().meanAvgTickTime)
-        && (tickBacklog < DynView.config.getCommonConfig().maxTickBacklog))
+        && (tickBacklog < DynView.config.getCommonConfig().maxTickBacklog/10)) // if tick backlog is 30, then should be below 3.
         {
             if (currentChunkUpdateDist < DynView.config.getCommonConfig().maxSimulationDist && rand.nextInt(10) != 0)
             {

--- a/src/main/java/com/dynview/ViewDistHandler/ServerDynamicViewDistanceManager.java
+++ b/src/main/java/com/dynview/ViewDistHandler/ServerDynamicViewDistanceManager.java
@@ -70,7 +70,7 @@ public class ServerDynamicViewDistanceManager implements IDynamicViewDistanceMan
                 currentChunkViewDist--;
                 if (DynView.config.getCommonConfig().logMessages)
                 {
-                    DynView.LOGGER.info("Mean tickTime:" + meanTickTime + "ms (Backlog:"+tickBacklog+") decreasing chunk view distance to: " + currentChunkViewDist);
+                    DynView.LOGGER.info("Mean tickTime: " + meanTickTime + "ms (Backlog:"+tickBacklog+") decreasing chunk view distance to: " + currentChunkViewDist);
                 }
                 server.getPlayerList().setViewDistance(currentChunkViewDist);
             }

--- a/src/main/java/com/dynview/config/CommonConfiguration.java
+++ b/src/main/java/com/dynview/config/CommonConfiguration.java
@@ -9,6 +9,8 @@ public class CommonConfiguration implements ICommonConfig
     public int     minChunkViewDist         = 10;
     public int     maxChunkViewDist         = 10;
     public int     meanAvgTickTime          = 45;
+    public int     maxTickBacklog          = 15;
+    public boolean     aggressiveScalebackEnabled          = true;
     public int     viewDistanceUpdateRate   = 60;
     public boolean logMessages              = false;
     public boolean chunkunload              = true;
@@ -40,6 +42,18 @@ public class CommonConfiguration implements ICommonConfig
         entry3.addProperty("meanAvgTickTime", meanAvgTickTime);
         root.add("meanAvgTickTime", entry3);
 
+        final JsonObject entry10 = new JsonObject();
+        entry10.addProperty("desc:",
+                "Tick backlog to trigger aggressive render distance scaleback. Above 40ticks will only trigger on severe lag. Below 5 can cause issues. Default: 15ticks, min: 5, max:250");
+        entry10.addProperty("maxTickBacklog", maxTickBacklog);
+        root.add("maxTickBacklog", entry10);
+
+        final JsonObject entry11 = new JsonObject();
+        entry11.addProperty("desc:",
+                "Aggressively scale back render distance, when maxTickBacklog is met. Default: true");
+        entry11.addProperty("aggressiveScaleback", aggressiveScalebackEnabled);
+        root.add("aggressiveScaleback", entry11);
+
         final JsonObject entry4 = new JsonObject();
         entry4.addProperty("desc:", "The change frequency of distances in seconds. Default: 30, min:1, max:1000");
         entry4.addProperty("viewDistanceUpdateRate", viewDistanceUpdateRate);
@@ -61,7 +75,7 @@ public class CommonConfiguration implements ICommonConfig
         root.add("adjustSimulationDistance", entry7);
 
         final JsonObject entry5 = new JsonObject();
-        entry5.addProperty("desc:", "Whether to output log messages for actions done. This can be helpful to balance the other settings nicely. Default = false");
+        entry5.addProperty("desc:", "Whether to output log messages for actions done. This can be helpful to balance the other settings nicely. Default: false");
         entry5.addProperty("logMessages", logMessages);
         root.add("logMessages", entry5);
 
@@ -81,6 +95,8 @@ public class CommonConfiguration implements ICommonConfig
         maxSimulationDist = Math.max(1, data.get("maxSimulationDist").getAsJsonObject().get("maxSimulationDist").getAsInt());
         maxChunkViewDist = Math.max(3, data.get("maxChunkViewDist").getAsJsonObject().get("maxChunkViewDist").getAsInt());
         meanAvgTickTime = data.get("meanAvgTickTime").getAsJsonObject().get("meanAvgTickTime").getAsInt();
+        maxTickBacklog = data.get("maxTickBacklog").getAsJsonObject().get("maxTickBacklog").getAsInt();
+        aggressiveScalebackEnabled = data.get("aggressiveScaleback").getAsJsonObject().get("aggressiveScaleback").getAsBoolean();
         viewDistanceUpdateRate = data.get("viewDistanceUpdateRate").getAsJsonObject().get("viewDistanceUpdateRate").getAsInt();
         logMessages = data.get("logMessages").getAsJsonObject().get("logMessages").getAsBoolean();
         adjustSimulationDistance = data.get("adjustSimulationDistance").getAsJsonObject().get("adjustSimulationDistance").getAsBoolean();

--- a/src/main/java/com/dynview/config/CommonConfiguration.java
+++ b/src/main/java/com/dynview/config/CommonConfiguration.java
@@ -9,8 +9,8 @@ public class CommonConfiguration implements ICommonConfig
     public int     minChunkViewDist         = 10;
     public int     maxChunkViewDist         = 10;
     public int     meanAvgTickTime          = 45;
-    public int     maxTickBacklog          = 15;
-    public boolean     aggressiveScalebackEnabled          = true;
+    public int     maxTickBacklog          = 30;
+    public boolean     aggressiveScalebackEnabled          = false;
     public int     viewDistanceUpdateRate   = 60;
     public boolean logMessages              = false;
     public boolean chunkunload              = true;
@@ -44,13 +44,13 @@ public class CommonConfiguration implements ICommonConfig
 
         final JsonObject entry10 = new JsonObject();
         entry10.addProperty("desc:",
-                "Tick backlog to trigger aggressive render distance scaleback. Above 40ticks will only trigger on severe lag. Below 5 can cause issues. Default: 15ticks, min: 5, max:250");
+                "Tick backlog to trigger aggressive render distance scaleback. Above 40ticks will only trigger on severe lag. Below 5 can cause issues. Default: 30ticks, min: 5, max:250");
         entry10.addProperty("maxTickBacklog", maxTickBacklog);
         root.add("maxTickBacklog", entry10);
 
         final JsonObject entry11 = new JsonObject();
         entry11.addProperty("desc:",
-                "Aggressively scale back render distance, when maxTickBacklog is met. Default: true");
+                "Aggressively scale back render distance, when maxTickBacklog is met. Default: false");
         entry11.addProperty("aggressiveScaleback", aggressiveScalebackEnabled);
         root.add("aggressiveScaleback", entry11);
 


### PR DESCRIPTION
new settings:
maxTickBacklog: Tick backlog to trigger aggressive render distance scaleback. Above 40ticks will only trigger on severe lag. Below 5 can cause issues. Default: 15ticks, min: 5, max:250
agressiveScaleback: Aggressively scale back render distance, when maxTickBacklog is met. Default: true

agressive scaleback is for when a sudden onset of server lag is produced due to player actions such as exploring chunks, farms starting, changing dimensions, etc. bypasses normal event loop of chunk increase/decrease.

backlog ticks measurement and comparison to maxTickBacklog for chunk increase/decrease decision.
backlog ticks are measured similar to how vanilla lag detection message is calculated